### PR TITLE
Fixed Search Name Index Error

### DIFF
--- a/Phocalstream_Shared/Data/Model/View/SearchModels.cs
+++ b/Phocalstream_Shared/Data/Model/View/SearchModels.cs
@@ -62,7 +62,7 @@ namespace Phocalstream_Shared.Data.Model.View
                 string[] months = this.Months.Split(',');
                 foreach (var m in months)
                 {
-                    monthNames.Add(CultureInfo.CurrentCulture.DateTimeFormat.GetMonthName(Convert.ToInt16(m) + 1));
+                    monthNames.Add(CultureInfo.CurrentCulture.DateTimeFormat.GetMonthName(Convert.ToInt16(m)));
                 }
 
             }


### PR DESCRIPTION
Fixes #17.

Changed the indexing of the name creation so that it matches the action selection: removes and (i + 1) error which, for example, showed October instead of September.
