### PR TITLE
Search Caching

### DIFF
--- a/Phocalstream_Core/Service/SearchService.cs
+++ b/Phocalstream_Core/Service/SearchService.cs
@@ -95,14 +95,14 @@ namespace Phocalstream_Service.Service
             return SiteRepository.GetAll().Select(s => s.Name).ToList<string>();
         }
 
-        public int SearchResultCount(QuickSearchModel model)
+        public int SearchResultCount(SearchModel model)
         {
             string select = GetQuickSearchQuery(model);
             List<long> ids = QuickSearch(select);
             return ids.Count;
         }
 
-        public long SearchResultPhotoId(QuickSearchModel model)
+        public long SearchResultPhotoId(SearchModel model)
         {
             string select = GetQuickSearchQuery(model);
             List<long> ids = QuickSearch(select);
@@ -118,6 +118,7 @@ namespace Phocalstream_Service.Service
                 return 0;
             }
         }
+
 
         public List<long> QuickSearch(string query)
         {
@@ -144,6 +145,22 @@ namespace Phocalstream_Service.Service
             }
 
             return Ids;
+        }
+
+        public void ValidateCache(SearchModel model, int currentCount)
+        {
+            var collectionName = model.CreateCollectionName();
+            var containerID = collectionName.GetHashCode().ToString();
+
+            Collection collection = CollectionRepository.Find(c => c.ContainerID == containerID, c => c.Photos).FirstOrDefault();
+
+            if (collection != null)
+            {
+                if (collection.Photos.Count() != currentCount)
+                {
+                    DeleteSearch(collection.ID);
+                }
+            }
         }
 
         public SearchMatches Search(SearchModel model)
@@ -177,7 +194,7 @@ namespace Phocalstream_Service.Service
             return result;
         }
 
-        private string GetQuickSearchQuery(QuickSearchModel model)
+        private string GetQuickSearchQuery(SearchModel model)
         {
             StringBuilder select = new StringBuilder();
             StringBuilder parameters = new StringBuilder();

--- a/Phocalstream_Shared/Data/Model/View/SearchModels.cs
+++ b/Phocalstream_Shared/Data/Model/View/SearchModels.cs
@@ -43,13 +43,13 @@ namespace Phocalstream_Shared.Data.Model.View
             StringBuilder name = new StringBuilder(); 
             name.Append("Showing photos ");
 
-            if(!String.IsNullOrWhiteSpace(Sites))
+            if(!String.IsNullOrWhiteSpace(Sites) && !Sites.Equals("undefined"))
             {
 
                 name.Append("from " + String.Join(", ", Sites.Split(',')) + " ");
             }
 
-            if (!String.IsNullOrWhiteSpace(Tags))
+            if (!String.IsNullOrWhiteSpace(Tags) && !Tags.Equals("undefined"))
             {
                 name.Append("tagged with " + String.Join(", ", Tags.Split(',')) + " ");
             }
@@ -70,7 +70,7 @@ namespace Phocalstream_Shared.Data.Model.View
                 name.Append("taken during " + String.Join(", ", monthNames.ToArray()) + " ");
             }
 
-            if (!String.IsNullOrWhiteSpace(Dates))
+            if (!String.IsNullOrWhiteSpace(Dates) && !Dates.Equals("undefined"))
             {
                 name.Append("taken on " + String.Join(", ", Dates.Split(',')) + " ");
             }
@@ -122,22 +122,5 @@ namespace Phocalstream_Shared.Data.Model.View
     {
         public List<Collection> Collections { get; set; }
         public string SearchPath { get; set; }
-    }
-
-    public class QuickSearchModel
-    {
-        public string Sites { get; set; }
-        public string Tags { get; set; }
-        public string Dates { get; set; }
-        public string Hours { get; set; }
-        public string Months { get; set; }
-        public bool IsEmpty()
-        {
-            return String.IsNullOrWhiteSpace(Sites) 
-                && String.IsNullOrWhiteSpace(Tags)
-                && String.IsNullOrWhiteSpace(Dates) 
-                && String.IsNullOrWhiteSpace(Hours)
-                && String.IsNullOrWhiteSpace(Months);
-        }
     }
 }

--- a/Phocalstream_Shared/Service/iSearchService.cs
+++ b/Phocalstream_Shared/Service/iSearchService.cs
@@ -15,8 +15,9 @@ namespace Phocalstream_Shared.Service
         void DeleteAllSearches();
         void GenerateCollectionManifest(List<string> fileNames, string savePath);
         List<string> GetSiteNames();
-        int SearchResultCount(QuickSearchModel model);
-        long SearchResultPhotoId(QuickSearchModel model);
+        int SearchResultCount(SearchModel model);
+        long SearchResultPhotoId(SearchModel model);
+        void ValidateCache(SearchModel model, int currentCount);
         SearchMatches Search(SearchModel model);
     }
 }

--- a/Phocalstream_Web/Controllers/Api/SearchController.cs
+++ b/Phocalstream_Web/Controllers/Api/SearchController.cs
@@ -32,7 +32,7 @@ namespace Phocalstream_Web.Controllers.Api
         [ActionName("count")]
         public HttpResponseMessage SearchCount(string hours, string months, string sites, string tags, string dates)
         {
-            QuickSearchModel model = new QuickSearchModel();
+            SearchModel model = new SearchModel();
             model.Sites = sites;
             model.Tags = tags;
             model.Dates = dates;
@@ -40,6 +40,9 @@ namespace Phocalstream_Web.Controllers.Api
             model.Months = months;
 
             int count = SearchService.SearchResultCount(model);
+
+            //check the search cache
+            SearchService.ValidateCache(model, count);
 
             HttpResponseMessage message = new HttpResponseMessage(HttpStatusCode.OK);
             message.Content = new StringContent(Convert.ToString(count));
@@ -51,7 +54,7 @@ namespace Phocalstream_Web.Controllers.Api
         [ActionName("photoId")]
         public HttpResponseMessage SearchPhotoId(string hours, string months, string sites, string tags, string dates)
         {
-            QuickSearchModel model = new QuickSearchModel();
+            SearchModel model = new SearchModel();
             model.Sites = sites;
             model.Tags = tags;
             model.Dates = dates;

--- a/Phocalstream_Web/Controllers/SearchController.cs
+++ b/Phocalstream_Web/Controllers/SearchController.cs
@@ -101,30 +101,27 @@ namespace Phocalstream_Web.Controllers
                 return RedirectToAction("Index", new { e = 2 });
             }
 
-            //check if the model exists
             var collectionName = model.CreateCollectionName();
             var containerID = collectionName.GetHashCode().ToString();
 
+            //check if the model exists
             Collection existingCollection = CollectionRepository.Find(c => c.ContainerID == containerID).FirstOrDefault();
             if (existingCollection != null)
             {
                 return RedirectToAction("SearchResult", new { collectionID = existingCollection.ID });
             }
+            //else, execute the search
             else
             {
-                //else, execute the search
                 SearchMatches result = SearchService.Search(model);
 
                 //if search yielded result, do proceed
                 if (result.Ids.Count > 0)
                 {
-                    //                Guid containerID = Guid.NewGuid();
-
                     //save the collection
                     Collection c = new Collection();
                     c.Name = collectionName;
                     c.ContainerID = containerID;
-                    //                c.ContainerID = containerID.ToString();
                     c.Type = CollectionType.SEARCH;
                     c.Photos = result.Matches;
                     CollectionRepository.Insert(c);
@@ -137,6 +134,7 @@ namespace Phocalstream_Web.Controllers
 
                     return RedirectToAction("SearchResult", new { collectionID = c.ID });
                 }
+                //else, redirect back to search page
                 else
                 {
                     return RedirectToAction("Index", new { e = 1 });


### PR DESCRIPTION
Fixes #18.

The search function now hashes the collection name and stores it as the containerID, allowing the system to check if the search has already been executed and just redirect to that page, instead of recreating the search.
