### PR TITLE
Bug Fix: Tag Filter in pivotviewer

### DIFF
--- a/Phocalstream_Core/Data/PhotoRepository.cs
+++ b/Phocalstream_Core/Data/PhotoRepository.cs
@@ -483,11 +483,20 @@ namespace Phocalstream_Web.Application.Data
 
             List<string> tags = GetPhotoTags((long)photo["ID"]);
 
-            foreach (var t in tags)
+            if (tags.Count == 0)
             {
                 facetValue = doc.CreateElement("String");
-                facetValue.SetAttribute("Value", t);
+                facetValue.SetAttribute("Value", "");
                 facet.AppendChild(facetValue);
+            }
+            else
+            {
+                foreach (var t in tags)
+                {
+                    facetValue = doc.CreateElement("String");
+                    facetValue.SetAttribute("Value", t);
+                    facet.AppendChild(facetValue);
+                }
             }
 
             facets.AppendChild(facet);


### PR DESCRIPTION
Fixed a bug in the generation of the site.cxml files. If a photo did not have any tags, that facet was left empty, which resulted in an improperly structured file which would not load into the pivotviewer.
