### PR TITLE
Force Camera Site Selection, User Upload

### DIFF
--- a/Phocalstream_Web/Controllers/AccountController.cs
+++ b/Phocalstream_Web/Controllers/AccountController.cs
@@ -221,7 +221,7 @@ namespace Phocalstream_Web.Controllers
             return View(model);
         }
         
-        public ActionResult UploadPhotos()
+        public ActionResult UploadPhotos(long collectionID = 0)
         {
             UserPhotoUpload model = new UserPhotoUpload();
 
@@ -231,6 +231,8 @@ namespace Phocalstream_Web.Controllers
             {
                 return RedirectToAction("CreateUserSite", new { e = 1 });
             }
+
+            ViewBag.CollectionID = collectionID;
 
             return View(model);
         }
@@ -273,7 +275,7 @@ namespace Phocalstream_Web.Controllers
             CollectionRepository.Insert(newCollection);
             Unit.Commit();
 
-            return new RedirectResult("UploadPhotos");
+            return RedirectToAction("UploadPhotos", new { @collectionID = newCollection.ID });
         }
 
         public ActionResult DeleteUserCollection(long collectionID)

--- a/Phocalstream_Web/Views/Account/UploadPhotos.cshtml
+++ b/Phocalstream_Web/Views/Account/UploadPhotos.cshtml
@@ -71,13 +71,25 @@
 {
     <script type="text/javascript">
 
-        var selectedCollectionID;
+        var selectedCollectionID = @ViewBag.CollectionID;
         var done;
+
+        $(function () {
+            var dropdown = document.getElementById(selectedCollectionID);
+          
+            if (dropdown != null) {
+                $("#dropdownTitle").text($(dropdown).text());
+                $("#dropdownTitle").val($(dropdown).text());
+            }
+        });
 
         $(function () {
             $(".dropdown-menu").on('click', 'li a', function () {
                 $("#dropdownTitle").text($(this).text());
                 $("#dropdownTitle").val($(this).text());
+
+                $("#dropdownTitle").removeClass("btn-danger");
+                $("#dropdownTitle").addClass("btn-default");
 
                 selectedCollectionID = $(this).attr('id');
             });
@@ -100,8 +112,16 @@
                     });
                 },
                 send: function (e, data) {
-                    data.url += selectedCollectionID;
-                    return true;
+                    if (selectedCollectionID == 0) {
+                        bootbox.alert("Please select a valid Camera Site from the dropdown.");
+                        $("#dropdownTitle").removeClass("btn-default");
+                        $("#dropdownTitle").addClass("btn-danger");
+                        return false;
+                    }
+                    else {
+                        data.url += selectedCollectionID;
+                        return true;
+                    }
                 },
                 done: function (e, data) {
                     data.context.text('');


### PR DESCRIPTION
Resolves #73.

Added logic to auto-select a camera site if the user navigates to the upload page directly from the site creation page. Also added a check to make sure a site was selected before uploading photos.
