### PR TITLE
Changed URL On Photo Upload

### DIFF
--- a/Phocalstream_Web/Content/CSS/Account.css
+++ b/Phocalstream_Web/Content/CSS/Account.css
@@ -40,6 +40,11 @@
     margin-bottom: 30px;
 }
 
+.upload-image {
+    width: 100%;
+    height: 100%;
+}
+
 .upload-progress {
     margin-top: 78.5px !important;
 }

--- a/Phocalstream_Web/Views/Account/UploadPhotos.cshtml
+++ b/Phocalstream_Web/Views/Account/UploadPhotos.cshtml
@@ -147,7 +147,7 @@
         });
 
         function showCollection() {
-            location.href = '@Url.Action("UserDefinedCollection", "Account")' + '?collectionID=' + selectedCollectionID;
+            location.href = '@Url.Action("Index", "Search")' + '?collectionID=' + selectedCollectionID;
         }
     </script>
 }

--- a/Phocalstream_Web/Views/Account/UploadPhotos.cshtml
+++ b/Phocalstream_Web/Views/Account/UploadPhotos.cshtml
@@ -125,7 +125,7 @@
                 },
                 done: function (e, data) {
                     data.context.text('');
-                    $('</div><img class="siteImage" src="/api/photo/low/' + data.result.id + '" alt="" />').appendTo(data.context);
+                    $('</div><img class="upload-image" src="/api/photo/low/' + data.result.id + '" alt="" />').appendTo(data.context);
                     if (done) {
                         bootbox.confirm("Images successfully uploaded. View them now?", function (result) {
                             if (result) {


### PR DESCRIPTION
The dialog after successful upload now directs the user to the photo results page, not a pivot view.