### PR TITLE
Set Cover Photo

### DIFF
--- a/Phocalstream_Web/Controllers/Api/SiteCollectionController.cs
+++ b/Phocalstream_Web/Controllers/Api/SiteCollectionController.cs
@@ -50,15 +50,18 @@ namespace Phocalstream_Web.Controllers.Api
 
         [HttpGet]
         [ActionName("updatecover")]
-        public void SetCoverPhoto(long photoId, long collectionId)
+        public void SetCoverPhoto(long photoId)
         {
-            Collection col = CollectionRepository.Single(c => c.ID == collectionId);
-            Photo photo = PhotoEntityRepository.Single(p => p.ID == photoId);
-            col.CoverPhoto = photo;
-            CollectionRepository.Update(col);
-            Unit.Commit();
+            Photo photo = PhotoEntityRepository.Single(p => p.ID == photoId, p => p.Site);
+            Collection col = CollectionRepository.Single(c => c.Site.ID == photo.Site.ID && c.Type == CollectionType.SITE);
+            if (col != null)
+            {
+                col.CoverPhoto = photo;
+                CollectionRepository.Update(col);
+                Unit.Commit();
+            }
         }
-
+        
         [HttpGet]
         [ActionName("list")]
         public IEnumerable<Object> GetSites()

--- a/Phocalstream_Web/Views/Search/Index.cshtml
+++ b/Phocalstream_Web/Views/Search/Index.cshtml
@@ -47,6 +47,23 @@
 
     var searchVM;
 
+    function setCover(photoId) {
+        var form;
+        form = $('<form />', {
+            action: '/api/sitecollection/updatecover',
+            method: 'GET',
+            style: 'display: none;'
+        });
+
+        form.append($('<input/>', {
+            type: 'hidden',
+            name: 'photoId',
+            value: photoId
+        }));
+
+        form.appendTo('body').submit();
+    }
+
     $(function(){
         searchVM = new ViewModel();
         ko.applyBindings(searchVM);
@@ -59,14 +76,20 @@
                 if (key == "full") {
                     window.open(basePhotoUrl + $(this).prop('id').split('-')[1], '_blank');
                 }
+                else if (key == "cover") {
+                    setCover($(this).prop('id').split('-')[1])
+                }
             },
             items: {
-                "full": {name: "View Full Image", icon: ""},
+                "full": {name: "View Full Image", icon: ""}
+                @if (Request.IsAuthenticated && User.IsInRole("Admin")) 
+                { 
+                    <text>, "cover": {name: "Set Cover Photo", icon: ""} </text> 
+                }
             }
         });
 
         checkListItemContents($("#ul-holder"));
-
     });
 </script>
 


### PR DESCRIPTION
An admin can now right click and set the cover photo for a camera site collection from the search interface.