### PR TITLE
Fix User Collection Error

### DIFF
--- a/Phocalstream_Web/Controllers/AccountController.cs
+++ b/Phocalstream_Web/Controllers/AccountController.cs
@@ -209,7 +209,7 @@ namespace Phocalstream_Web.Controllers
             model.TimelapseThumbnails = new List<ThumbnailModel>();
             model.CollectionThumbnails = new List<ThumbnailModel>();
 
-            model.Collections = CollectionRepository.Find(c => c.Owner.ID == User.ID, c => c.Photos);
+            model.Collections = CollectionRepository.Find(c => c.Owner.ID == User.ID, c => c.Photos).ToList<Collection>();
             foreach (var col in model.Collections)
             {
                 if (col.CoverPhoto == null)


### PR DESCRIPTION
Based on what I found online, it looks like this error can "randomly" be thrown from an `IEnumerable`. It appears simply calling `ToList<>` and forcing the query to execute can resolve it..? I can't replicate the error locally, though, so not sure if this actually fixes it. 

Will you review the code that sets up the various collection lists and make sure I'm not doing something else that's causing this problem?

Resolves #194.